### PR TITLE
Fix

### DIFF
--- a/vexil/lib/bot.ex
+++ b/vexil/lib/bot.ex
@@ -19,7 +19,7 @@ defmodule Bot do
   end
 
   def make(kind, team, x, y) do
-    apply(Bot, kind, {team, x, y})
+    apply(Bot, kind, [team, x, y])
   end
 
   def to_string(bot) when bot != nil do


### PR DESCRIPTION
Fixes:

``` elixir
** (ArgumentError) argument error
            :erlang.apply(Bot, :defender, {:red, 5, 5})
    (vexil) lib/bot.ex:22: Bot.make/4
    (vexil) lib/referee.ex:8: Referee.place/5
```

when calling:

``` elixir
Referee.place(%{}, :red, :defender, 5, 5)
```
